### PR TITLE
feature: add ability to skip fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ pub struct Pet {
     info: String,
     #[property(mut(public, suffix = "_mut"))]
     note: Option<String>,
+    #[property(skip)]
+    map: Vec<i32>,
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@ pub fn derive_property(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
         let name = &property.name;
         let (impl_generics, type_generics, where_clause_opt) = property.generics.split_for_impl();
         let methods = property.fields.iter().fold(Vec::new(), |mut r, f| {
-            r.append(&mut derive_property_for_field(f));
+            if !f.conf.skip {
+                r.append(&mut derive_property_for_field(f));
+            }
             r
         });
         let impl_methods = quote!(


### PR DESCRIPTION
I have struct with many fields,
and I need setters/getters for all of them.
But for one field:
other_info: FxHashMap<OtherInfo, String>,

I want setters/getters like this:
    pub fn get_other_info(&self, key: OtherInfo) -> Option<&str> {
    pub fn set_other_info(&mut self, key: OtherInfo, value: String) {

So I prefer skip particular field and implement getters/setters for this field
manually. I try to mimic serde syntax for skipping fields to make it
more easy to learn.