### PR TITLE
No return from setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ pub struct Pet {
     note: Option<String>,
     #[property(skip)]
     map: Vec<i32>,
+    #[property(set(noret))]
+    just_set: i32,
 }
 ```
 
@@ -192,6 +194,15 @@ impl Pet {
     #[inline]
     pub fn note_mut(&mut self) -> &mut Option<String> {
         &mut self.note
+    }
+    #[inline]
+    pub fn just_set(&self) -> i32 {
+        self.just_set
+    }
+    #[inline]
+    fn set_just_set<T: Into<i32>>(&mut self, val: T) -> () {
+        self.just_set = val.into();
+        ()
     }
 }
 impl PartialEq for Pet {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -13,6 +13,7 @@ const ATTR_NAME: &str = "property";
 const SKIP: &str = "skip";
 const GET_TYPE_OPTIONS: (&str, Option<&[&str]>) = ("type", Some(&["ref", "copy", "clone"]));
 const SET_TYPE_OPTIONS: (&str, Option<&[&str]>) = ("type", Some(&["ref", "own"]));
+const SET_NORET: &str = "noret";
 const NAME_OPTION: (&str, Option<&[&str]>) = ("name", None);
 const PREFIX_OPTION: (&str, Option<&[&str]>) = ("prefix", None);
 const SUFFIX_OPTION: (&str, Option<&[&str]>) = ("suffix", None);
@@ -77,6 +78,7 @@ pub(crate) struct SetFieldConf {
     pub(crate) vis: VisibilityConf,
     pub(crate) name: MethodNameConf,
     pub(crate) typ: SetTypeConf,
+    pub(crate) noret: bool,
 }
 
 #[derive(Clone)]
@@ -382,6 +384,7 @@ impl ::std::default::Default for FieldConf {
                     suffix: "".to_owned(),
                 },
                 typ: SetTypeConf::Ref,
+                noret: false,
             },
             mut_: MutFieldConf {
                 vis: VisibilityConf::Crate,
@@ -495,7 +498,8 @@ impl FieldConf {
                         }
                     }
                     "set" => {
-                        let paths = check_path_params(&path_params, &[VISIBILITY_OPTIONS])?;
+                        let paths =
+                            check_path_params(&path_params, &[VISIBILITY_OPTIONS, &[SET_NORET]])?;
                         let namevalues = check_namevalue_params(
                             &namevalue_params,
                             &[NAME_OPTION, PREFIX_OPTION, SUFFIX_OPTION, SET_TYPE_OPTIONS],
@@ -514,6 +518,9 @@ impl FieldConf {
                             SetTypeConf::parse_from_input(&namevalues, list.path.span())?
                         {
                             self.set.typ = choice;
+                        }
+                        if Some(&Some(SET_NORET)) == paths.get(1) {
+                            self.set.noret = true;
                         }
                     }
                     "mut" => {


### PR DESCRIPTION
For some cases it is very inconvenient to have return value in setter,
for example:

```rust
fn f() {}
fn g() -> i32 {
    17
}

fn main() {
    let x = 1;
    match x {
        1 => f(),
        2 => g(),
        3 => println!("Hi"),
        _ => println!("ohter"),
    }
}
```

this code doesn't compile, because of `g` return value,
I don't use value from setters, so it would be convenient to have such option
to make it possible for easy way to deal with generated code.

Depend on #5 