### PR TITLE
New option 'strip_option'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Generate several common methods for structs automatically.
 
   - `replace`: input is a mutable reference and return the old value.
 
+- ``#[property(set(strip_option))]` accepts `T` as property value instead of `Option<T>`
+
 - If there are more than one filed have the `ord` attribute, the [`PartialEq`] and [`PartialOrd`] will be implemented automatically.
 
   - A serial number is required for the `ord` field attribute, it's an unsigned number with a `_` prefix.
@@ -109,7 +111,7 @@ pub struct Pet {
     info: String,
     #[property(get(disable), set(type = "replace"))]
     pub tag: Vec<String>,
-    #[property(mut(public, suffix = "_mut"))]
+    #[property(mut(public, suffix = "_mut"), set(strip_option))]
     note: Option<String>,
     #[property(set(type = "replace"))]
     price: Option<u32>,
@@ -204,8 +206,8 @@ impl Pet {
         self.note.as_ref()
     }
     #[inline]
-    fn set_note<T: Into<Option<String>>>(&mut self, val: T) -> &mut Self {
-        self.note = val.into();
+    fn set_note<T: Into<String>>(&mut self, val: T) -> &mut Self {
+        self.note = Some(val.into());
         self
     }
     #[inline]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Generate several common methods for structs automatically.
 
   - `replace`: input is a mutable reference and return the old value.
 
-- ``#[property(set(strip_option))]` accepts `T` as property value instead of `Option<T>`
+- `#[property(set(strip_option))]` accepts `T` as property value instead of `Option<T>`
 
 - If there are more than one filed have the `ord` attribute, the [`PartialEq`] and [`PartialOrd`] will be implemented automatically.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,38 @@ fn derive_property_for_field(field: &FieldDef) -> Vec<proc_macro2::TokenStream> 
                     }
                 ),
             },
+            FieldType::Option_(inner_type) if field_conf.set.strip_option => match field_conf.set.typ {
+                SetTypeConf::Ref => quote!(
+                    #visibility fn #method_name<T: Into<#inner_type>>(
+                        &mut self, val: T
+                    ) -> &mut Self {
+                        self.#field_name = Some(val.into());
+                        self
+                    }
+                ),
+                SetTypeConf::Own => quote!(
+                    #visibility fn #method_name<T: Into<#inner_type>>(
+                        mut self, val: T
+                    ) -> Self {
+                        self.#field_name = Some(val.into());
+                        self
+                    }
+                ),
+                SetTypeConf::None_ => quote!(
+                    #visibility fn #method_name<T: Into<#inner_type>>(
+                        &mut self, val: T
+                    ) {
+                        self.#field_name = Some(val.into());
+                    }
+                ),
+                SetTypeConf::Replace => quote!(
+                    #visibility fn #method_name<T: Into<#inner_type>>(
+                        &mut self, val: T
+                    ) -> #field_type {
+                        self.#field_name.replace(val.into())
+                    }
+                ),
+            },
             _ => match field_conf.set.typ {
                 SetTypeConf::Ref => quote!(
                     #visibility fn #method_name<T: Into<#field_type>>(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,6 +15,7 @@ const GET_TYPE_OPTIONS: (&str, Option<&[&str]>) = ("type", Some(&["ref", "copy",
 const SET_TYPE_OPTIONS: (&str, Option<&[&str]>) =
     ("type", Some(&["ref", "own", "none", "replace"]));
 const NAME_OPTION: (&str, Option<&[&str]>) = ("name", None);
+const STRIP_OPTION: &[&str] = &["strip_option"];
 const PREFIX_OPTION: (&str, Option<&[&str]>) = ("prefix", None);
 const SUFFIX_OPTION: (&str, Option<&[&str]>) = ("suffix", None);
 const VISIBILITY_OPTIONS: &[&str] = &["disable", "public", "crate", "private"];
@@ -80,6 +81,7 @@ pub(crate) struct SetFieldConf {
     pub(crate) vis: VisibilityConf,
     pub(crate) name: MethodNameConf,
     pub(crate) typ: SetTypeConf,
+    pub(crate) strip_option: bool,
 }
 
 #[derive(Clone)]
@@ -387,6 +389,7 @@ impl ::std::default::Default for FieldConf {
                     suffix: "".to_owned(),
                 },
                 typ: SetTypeConf::Ref,
+                strip_option: false,
             },
             mut_: MutFieldConf {
                 vis: VisibilityConf::Crate,
@@ -504,7 +507,7 @@ impl FieldConf {
                         }
                     }
                     "set" => {
-                        let paths = check_path_params(&path_params, &[VISIBILITY_OPTIONS])?;
+                        let paths = check_path_params(&path_params, &[VISIBILITY_OPTIONS, STRIP_OPTION])?;
                         let namevalues = check_namevalue_params(
                             &namevalue_params,
                             &[NAME_OPTION, PREFIX_OPTION, SUFFIX_OPTION, SET_TYPE_OPTIONS],
@@ -524,6 +527,7 @@ impl FieldConf {
                         {
                             self.set.typ = choice;
                         }
+                        self.set.strip_option = paths[1].is_some();
                     }
                     "mut" => {
                         let paths = check_path_params(&path_params, &[VISIBILITY_OPTIONS])?;


### PR DESCRIPTION
The new option `strip_option` create setter methods for `T` by stripping `Option` for fields with `Option<T>`. It reduce boiler plate code by using the method and open the possibility to create more builder like methods.